### PR TITLE
fix error when installing mapage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "man": "./rfc.1",
   "scripts": {
-    "install": "make man",
     "test": "make test"
   },
   "keywords": [


### PR DESCRIPTION
`npm` will install man page, no need to install manually
https://docs.npmjs.com/files/package.json#man

```sh
npm install https://github.com/leesei/rfc#man-fix -g
```

Actually we can port the whole Makefile to npm script, what's your opinion?
