### PR TITLE
[fix] #12 Premature `stream.end()` in `search()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ rfc(1)
 
 [IETF](http://www.ietf.org) [RFC](http://www.ietf.org/rfc) reader tool
 
-## installl
+## install
 
 with **npm**
 
@@ -21,7 +21,7 @@ $ npm install github:jwerle/rfc -g
 
 **search** 
 
-```sh
+```
 $ rfc search punycode
   ... searching
 
@@ -35,7 +35,7 @@ $ rfc search punycode
 
 **view**
 
-```sh
+```
 $ rfc open 3492
 
 Network Working Group                                        A. Costello
@@ -73,7 +73,7 @@ Abstract
 var rfc = require('rfc')
 
 var count = 0;
-rfc.search('punycode')
+rfc.search('idna')
 .on('error', function (err) {
   // handle error
 })
@@ -91,7 +91,6 @@ rfc.search('punycode')
 ### RFC\_BASE\_URL
 
 IETF RFC Base URL
-
 
 ### RFC\_INDEX\_URL
 
@@ -132,6 +131,11 @@ rfc.search('idna')
     result.desc);
 });
 ```
+
+## debug
+
+`DEBUG` tags: `rfc:search`, `rfc:match`, `rfc:sync`
+See [visionmedia/debug](https://github.com/visionmedia/debug) for details on usage.
 
 ## license
 

--- a/bin/rfc
+++ b/bin/rfc
@@ -43,7 +43,7 @@ function printf () {
 }
 
 function c (ch, n) {
-  var s = "", i = 0;
+  var s = '', i = 0;
   for (; i < n; ++i) s += ch;
   return s;
 }
@@ -84,7 +84,7 @@ for (i = 0; (arg = argv[i]); ++i) {
       break;
 
     default:
-      e("unknown option: `"+ arg +"'");
+      e('unknown option: "'+ arg +'"');
       usage();
       exit(1);
   }
@@ -143,27 +143,27 @@ function version () {
 
 function help () {
   usage();
-  o("options:");
-  o("  -r, --regex       use regex query input");
-  o("  -v, --verbose     show verbose output");
-  o("  -V, --version     output version");
-  o("  -h, --help        display this message");
+  o('options:');
+  o('  -r, --regex       use regex query input');
+  o('  -v, --verbose     show verbose output');
+  o('  -V, --version     output version');
+  o('  -h, --help        display this message');
   o();
-  o("commands:");
-  o("  sync              sync remote rfc index file");
-  o("  search <query>    search rfc index");
-  o("  open <rfc>        open an rfc document by id");
-  o("  list              list all local rfc documents");
-  o("  index             show local rfc index");
-  o("  clear             clear local cache");
+  o('commands:');
+  o('  sync              sync remote rfc index file');
+  o('  search <query>    search rfc index');
+  o('  open <rfc>        open an rfc document by id');
+  o('  list              list all local rfc documents');
+  o('  index             show local rfc index');
+  o('  clear             clear local cache');
   exit(0);
 }
 
 function sync () {
   var bar = null;
 
-  o("");
-  o("  ... syncing from '%s'", rfc.RFC_INDEX_URL);
+  o('');
+  o('  ... syncing from "%s"', rfc.RFC_INDEX_URL);
 
   rfc.sync()
   .on('length', function (len) {
@@ -178,11 +178,11 @@ function sync () {
     bar.tick(n);
   })
   .on('error', function (err) {
-    e("error: %s", err.message);
+    e('error: %s', err.message);
     exit(1);
   })
   .on('end', function () {
-    o("  ✓ synced! (%s)",
+    o('  ✓ synced! (%s)',
       p.resolve(rfc.RFC_CACHE, rfc.RFC_CACHE_INDEX));
     exit(0);
   });
@@ -201,22 +201,22 @@ function search (query) {
 
   var count = 0;
 
-  o("  ... searching");
+  o('  ... searching');
   o();
   rfc.search(query, true)
   .on('error', function (err) {
-    e("error: %s", err.message);
+    e('error: %s', err.message);
     exit(1);
   })
   .on('result', function (result) {
     count++;
-    printf("  %d   ", result.rfc);
-    printf("%s\n\n", result.desc.replace(/\n/gm, '\n    '));
-    printf("  %s\n\n", c('-', 78));
+    printf('  %d   ', result.rfc);
+    printf('%s\n\n', result.desc.replace(/\n/gm, '\n    '));
+    printf('  %s\n\n', c('-', 78));
   })
   .on('end', function () {
     o()
-    o("  ... (%d) result%s", count, count > 1? 's' : '');
+    o('  ... (%d) result%s', count, count > 1? 's' : '');
     exit(0);
   });
 }
@@ -232,7 +232,7 @@ function open (arg) {
   if ('index' == query) {
     rfc.open(rfc.RFC_CACHE +'/'+ rfc.RFC_CACHE_INDEX)
     .on('error', function (err) {
-      e("error: %s", err.message);
+      e('error: %s', err.message);
       exit(1);
     }).on('end', function () {
       exit(0);
@@ -249,17 +249,22 @@ function open (arg) {
 
   // do search
   rfc.search(query)
-  .on('error', function (err) {
-    e("error: %s", err.message);
-    exit(1);
-  })
+    .on('error', function (err) {
+      e('error: %s', err.message);
+      exit(1);
+    })
     .on('result', function (result) {
-      if (true === resultOpened) {
+      if (resultOpened) {
         return;
       }
 
       resultOpened = true;
       openRFC(result);
+    })
+    .on('end', function () {
+      if (!resultOpened) {
+        e('"%s" not found', query);
+      }
     });
 
   // handles sync (download) and open
@@ -270,7 +275,7 @@ function open (arg) {
 
     rfc.sync()
       .on('error', function (err) {
-        e("error: %s", err);
+        e('error: %s', err.message);
       })
       .on('end', function () {
         rfc.open();
@@ -282,16 +287,16 @@ function list () {
   o();
   rfc.list()
   .on('error', function (err) {
-    e("error: %s", err.message);
+    e('error: %s', err.message);
     exit(1);
   })
   .on('item', function (item) {
-    o("  * %s - (%s)", item.name, item.path);
+    o('  * %s - (%s)', item.name, item.path);
   })
   .on('empty', function () {
     o()
-    o("  no local rfc documents found!");
-    o("  try `rfc sync` first");
+    o('  no local rfc documents found!');
+    o('  try `rfc sync` first');
     o();
     exit(1);
   });
@@ -301,7 +306,7 @@ function list () {
 
 function clear () {
   o();
-  o("  ... clearing '%s'", rfc.RFC_CACHE);
+  o('  ... clearing "%s"', rfc.RFC_CACHE);
   o();
   rfc.clear();
   exit(0);
@@ -311,17 +316,17 @@ function index () {
   o();
   rfc.search('*', {local: true})
   .on('error', function (err) {
-    e("error: %s", err.message);
+    e('error: %s', err.message);
     exit(1);
   })
   .on('result', function (result) {
-    printf("  %d   ", result.rfc);
-    printf("%s\n\n", result.desc.replace(/\n/gm, '\n    '))
-    printf("  %s\n\n", c('-', 78));
+    printf('  %d   ', result.rfc);
+    printf('%s\n\n', result.desc.replace(/\n/gm, '\n    '));
+    printf('  %s\n\n', c('-', 78));
   })
   .on('end', function () {
     o();
-    o("  ... Try `rfc open index` too view the index in your PAGER");
+    o('  ... Try `rfc open index` too view the index in your PAGER');
     o();
   });
 }

--- a/bin/rfc
+++ b/bin/rfc
@@ -227,7 +227,7 @@ function open (arg) {
   var tmp = null;
   var m = 0;
   var query = arg.join(' ');
-  var resultOpen = false;
+  var resultOpened = false;
 
   if ('index' == query) {
     rfc.open(rfc.RFC_CACHE +'/'+ rfc.RFC_CACHE_INDEX)
@@ -241,58 +241,41 @@ function open (arg) {
     return;
   }
 
-  if (!isNaN(parseInt(query, 10))) {
-    if (query.length < 4) {
-      tmp = query.length - 4;
-      m = tmp >> 31;
-      tmp = (m ^ tmp) - m;
-      for (n = 0; n < tmp; ++n) {
-        query = '0' + query;
-      }
-    }
+  // open with RFC number
+  var num = parseInt(query, 10);
+  if (!isNaN(num)) {
+    return openRFC(new rfc.RFC({rfc: num}));
   }
 
-  item = new rfc.RFC({rfc: query});
-
-  if (item.isSynced()) {
-    return item.open();
-  }
-
+  // do search
   rfc.search(query)
   .on('error', function (err) {
     e("error: %s", err.message);
     exit(1);
   })
-  .on('result', function (result) {
-    results.push(result);
-
-    if (true == resultOpen) {
-      return;
-    }
-
-    if (0 == results.length) {
-      o();
-      o("  no results");
-    } else if (results.length > 1) {
-      e("error: open: returned '%d' RFC results", results.length);
-      e("error: open: '%s' is too ambiguous", query);
-      e("error: open: try `rfc search %s`", query);
-      exit(1);
-    } else {
-      var result = results.shift();
-      var stream = result.open();
-      resultOpen = true;
-      if (null == stream) {
-        e("error: open: an unknown error occured");
-        exit(1);
+    .on('result', function (result) {
+      if (true === resultOpened) {
+        return;
       }
 
-      stream.on('error', function (err) {
-        error("error: open: %s", err.message);
-        exit(1);
-      });
+      resultOpened = true;
+      openRFC(result);
+    });
+
+  // handles sync (download) and open
+  function openRFC (rfc) {
+    if (rfc.isSynced()) {
+      return rfc.open();
     }
-  })
+
+    rfc.sync()
+      .on('error', function (err) {
+        e("error: %s", err);
+      })
+      .on('end', function () {
+        rfc.open();
+      });
+  }
 }
 
 function list () {

--- a/index.js
+++ b/index.js
@@ -422,6 +422,8 @@ RFC.prototype.sync = function () {
     .get(exports.RFC_BASE_URL + name)
     .end(function (err, res) {
       if (err) {
+        SYNCD('RESPONSE Error', err);
+        return stream.emit('error', err);
       }
 
       SYNCD('RESPONSE >', path);

--- a/index.js
+++ b/index.js
@@ -11,13 +11,16 @@ var through = require('through')
   , rmrf = require('rmrf')
   , osHomedir = require('os-homedir');
 
-var fread = fs.readFileSync;
+var SEARCHD = require('debug')('rfc:search');
+var MATCHD = require('debug')('rfc:match');
+var SYNCD = require('debug')('rfc:sync');
+
 var fexists = fs.existsSync;
 
 /**
  * IETF RFC Base URL
  *
- * @public
+ * @default
  */
 
 exports.RFC_BASE_URL = 'http://www.ietf.org/rfc';
@@ -25,7 +28,7 @@ exports.RFC_BASE_URL = 'http://www.ietf.org/rfc';
 /**
  * IETF RFC Index file URL
  *
- * @public
+ * @default http://www.ietf.org/rfc/rfc-index.txt
  */
 
 exports.RFC_INDEX_URL = exports.RFC_BASE_URL + '/rfc-index.txt';
@@ -33,7 +36,7 @@ exports.RFC_INDEX_URL = exports.RFC_BASE_URL + '/rfc-index.txt';
 /**
  * Default RFC cache folder
  *
- * @public
+ * @default $HOME/.rfc.d
  */
 
 exports.RFC_CACHE = p.resolve(osHomedir(), '.rfc.d');
@@ -41,7 +44,7 @@ exports.RFC_CACHE = p.resolve(osHomedir(), '.rfc.d');
 /**
  * Default RFC Index cache file (file name)
  *
- * @public
+ * @default
  */
 
 exports.RFC_CACHE_INDEX = 'rfc-index';
@@ -49,12 +52,13 @@ exports.RFC_CACHE_INDEX = 'rfc-index';
 /**
  * Syncs RFC Index file to `RFC_CACHE/RFC_CACHE_INDEX`
  *
- * @public
- * @function
  * @return {Stream}
+ * @emits length
+ * @emits progress
+ * @emits data
+ * @emits error
+ * @emits end
  */
-
-exports.sync = sync;
 function sync () {
   var stream = through();
   var path = p.resolve(exports.RFC_CACHE, exports.RFC_CACHE_INDEX);
@@ -66,56 +70,53 @@ function sync () {
 
     fetchIndex();
   });
-
   return stream;
 
   function fetchIndex () {
+    SYNCD('GET index', this.rfc, exports.RFC_INDEX_URL);
     agent.get(exports.RFC_INDEX_URL, function (err, res) {
       if (null !== err) {
         return stream.emit('error', err);
       }
 
-      var out = fs.createWriteStream(path, {
-        flags: 'w+'
-      });
+      SYNCD('RESPONSE >', path);
+      var out = fs.createWriteStream(path);
 
       var line = null;
       var lines = null;
-      var len = 0;
 
-      if (0 !== res.text.length) {
-        lines = res.text.split('\n');
-        len = lines.length;
-
-        stream.emit('length', len);
-
-        stream.pipe(out);
-
-        // into chunks
-        while (null != (line = lines.shift())) {
-          stream.emit('progress', 1);
-          line += '\n';
-          stream.write(line);
-        }
-
-        stream.end();
+      if (0 === res.text.length) {
+        return stream.end();
       }
+
+      lines = res.text.split('\n');
+      stream.emit('length', lines.length);
+      stream.pipe(out);
+
+      // into chunks
+      while (null != (line = lines.shift())) {
+        stream.emit('progress', 1);
+        line += '\n';
+        stream.write(line);
+      }
+      stream.end();
     });
   }
 }
+exports.sync = sync;
 
 /**
  * Searches RFC Index based on a query
  *
- * @public
- * @function
- * @param {String|Regex} query
+ * @param {String|Regex} [query='*']
  * @param {Object} [opts]
+ * @param {Boolean} [opts.useRemote = false] - always use remote index
  * @return {Stream}
+ * @emits result
+ * @emits error
+ * @emits end
  * @todo  support query function
  */
-
-exports.search = search;
 function search (query, opts) {
   var stream = through(write);
   var indexFile = p.resolve(exports.RFC_CACHE, exports.RFC_CACHE_INDEX);
@@ -129,15 +130,16 @@ function search (query, opts) {
   }
 
   if (opts.useRemote || !fexists(indexFile)) {
+    SEARCHD('REMOTE RFC_INDEX');
     agent.get(exports.RFC_INDEX_URL, function (err, res) {
       if (null !== err) {
         return stream.emit('error', err);
       }
 
       parse(res.text);
-
     });
   } else {
+    SEARCHD('CACHED RFC_INDEX');
     fs.readFile(indexFile, function (err, buf) {
       if (null !== err) {
         return stream.emit('error', err);
@@ -149,6 +151,10 @@ function search (query, opts) {
 
   return stream;
 
+  /**
+   * parse RFC documents in RFC_CACHE_INDEX and write to `stream`
+   * @param  {String} data - content of RFC_CACHE_INDEX
+   */
   function parse (data) {
     var line = null;
     var nline = null;
@@ -186,9 +192,20 @@ function search (query, opts) {
       }
     }
 
-    stream.end();
+    // DO NOT end stream here
+    // stream should emit all 'result's and then 'end'
+    // use empty string to signal EOS
+    SEARCHD('END parse()');
+    stream.write('');
   }
 
+  /**
+   * data handler of the `through` stream
+   * search `query` in `chunk` and emit `result` if matched
+   *
+   * @param  {String} chunk - one RFC in RFC_CACHE_INDEX, written by `parse()`
+   * @emit result
+   */
   function write (chunk) {
     var regex = null;
     var num = null;
@@ -201,6 +218,12 @@ function search (query, opts) {
     } else {
       regex = RegExp('(' + query + ')', 'ig');
     }
+
+    if (str === '') {
+      SEARCHD('END write');
+      stream.end();
+    }
+    SEARCHD('CHUNK[%d]: ', str.length, str);
 
     if (regex.test(str)) {
       parts = str.split(/^([0-9]+)\s+/);
@@ -231,31 +254,22 @@ function search (query, opts) {
       }
 
       var rfc = new RFC({rfc: num, desc: desc});
+      MATCHD('RFC[%d] local[%s] synced[%s]', num, !!opts.local, rfc.isSynced());
 
-      if (opts.local && rfc.isSynced()) {
-        stream.emit('result', rfc);
-      } else if (!opts.local && !rfc.isSynced()) {
-        rfc.sync().on('error', function (err) {
-          stream.emit('error', err);
-        }).on('end', function () {
-          stream.emit('result', rfc);
-        });
-      } else {
-        stream.emit('result', rfc);
-      }
+      return stream.emit('result', rfc);
     }
   }
 }
+exports.search = search;
 
 /**
- * Opens a file in the RFC cache with the user `PAGER`
+ * Opens a file with the user `PAGER`
  *
- * @public
- * @function
- * @param {String} path
+ * @param {String} file - path of file to open
+ * @return {Stream}
+ * @emits error
+ * @emits end
  */
-
-exports.open = open;
 function open (file) {
   var stream = through();
   var pager = null;
@@ -284,39 +298,30 @@ function open (file) {
     stream.end();
   }
 }
+exports.open = open;
 
 /**
  * Removes everything from the `RFC_CACHE`
  *
- * @public
- * @function
  */
-
-exports.clear = clear;
 function clear () {
   return rmrf(exports.RFC_CACHE);
 }
+exports.clear = clear;
 
 /**
  * Clears RFC Index cache
  *
- * @public
- * @function
  */
-
-exports.clearIndex = clearIndex;
 function clearIndex () {
   return rmrf(p.resolve(exports.RFC_CACHE, exports.RFC_CACHE_INDEX));
 }
+exports.clearIndex = clearIndex;
 
 /**
  * Lists all downloaded RFC files in `RFC_CACHE`
  *
- * @public
- * @function
  */
-
-exports.list = list;
 function list () {
   var stream = through();
   var ls = null;
@@ -355,83 +360,76 @@ function list () {
 
   return stream;
 }
+exports.list = list;
 
 /**
  * Removes an RFC document from the cache
  *
- * @public
- * @function
  * @param {String|Number} rfc
  */
-
-exports.clearRfc = clearRfc;
 function clearRfc (rfc) {
   return rmrf(rfcCachePath(rfc));
 }
+exports.clearRfc = clearRfc;
 
 /**
  * `RFC` class representing an RFC document
  *
- * @public
- * @class RFC
+ * @class
  * @param {Object} opts
+ * @param {Number} opts.rfc - RFC number
+ * @param {String} [opts.desc = ''] - RFC description
+ * @param {String} [opts.path = rfcCachePath(opts.rfc)] - Path for the downloaded RFC document
  */
-
-exports.RFC = RFC;
 function RFC (opts) {
-  /** RFC number */
+  if (isNaN(opts.rfc)) {
+    throw new Error('rfc should be a number');
+  }
+
   this.rfc = Number(opts.rfc);
-  /** RFC description */
-  this.desc = String(opts.desc);
-  /** Path for the downloaded RFC document */
-  this.path = opts.path || rfcCachePath(this.rfc);
+  this.desc = String(opts.desc || '');
+  this.path = opts.path || rfcCachePath(opts.rfc);
 }
+exports.RFC = RFC;
 
 /**
- * Opens the RFC with the users `$PAGER`
+ * Opens the RFC document with the user's `$PAGER`
  *
- * @public
- * @function
  */
-
 RFC.prototype.open = function () {
   return exports.open(this.path);
 };
 
 /**
- * Predicate to test if RFC is sync'd to file system
+ * Predicate to test if the RFC document is sync'd to file system
  *
- * @public
- * @function
  */
-
 RFC.prototype.isSynced = function () {
   return fexists(this.path);
 };
 
 /**
- * Syncs RFC to file system
+ * Syncs the RFC document to file system
  *
- * @public
- * @function
  */
-
 RFC.prototype.sync = function () {
   var stream = through();
   var name = '/rfc' + this.rfc + '.txt';
-  var fpath = rfcCachePath(this.rfc);
+  var path = this.path;
 
-  agent.get(exports.RFC_BASE_URL + name, function (err, res) {
-    if (err) {
-      return stream.emit('error', err);
-    }
+  SYNCD('GET rfc[%d]', this.rfc, exports.RFC_BASE_URL + name);
+  agent
+    .get(exports.RFC_BASE_URL + name)
+    .end(function (err, res) {
+      if (err) {
+      }
 
-    var out = fs.createWriteStream(fpath);
-    stream.pipe(out);
-    stream.write(trim(res.text));
-    stream.end();
-    out.end();
-  });
+      SYNCD('RESPONSE >', path);
+      stream.pipe(fs.createWriteStream(path));
+      stream.write(res.text);
+      stream.end();
+      // will this end prematurely?
+    });
 
   return stream;
 };
@@ -439,9 +437,8 @@ RFC.prototype.sync = function () {
 /**
  * Trim utility
  *
- * @function
+ * @private
  */
-
 function trim (str) {
   var i = 0;
   str = str.replace(/^\s+/, '').trim();
@@ -458,9 +455,11 @@ function trim (str) {
 /**
  * Get path of RFC document in cache
  *
- * @function
+ * @private
+ * @param {String|Number} rfc - RFC number
  */
 function rfcCachePath (rfc) {
-  return p.resolve(exports.RFC_CACHE,
+  return p.resolve(
+    exports.RFC_CACHE,
     'rfc' + rfc + '.txt');
 }

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -6,7 +6,6 @@
         "include": ["./index.js"]
     },
     "opts": {
-        "access": "public",
         "encoding": "utf8",
         "destination": "./docs/",
         "recurse": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rfc",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "IETF RFC reader tool",
   "main": "index.js",
   "preferGlobal": true,
@@ -11,8 +11,7 @@
   "scripts": {
     "docs": "jsdoc -c ./jsdoc.conf.json",
     "man": "curl -# -F page=@rfc.1.md -o rfc.1 http://mantastic.herokuapp.com",
-    "test": "node test.js",
-    "mypublish": "npm run man && npm publish"
+    "test": "node test.js"
   },
   "keywords": [
     "ietf",
@@ -22,15 +21,16 @@
   "author": "Joseph Werle",
   "license": "MIT",
   "dependencies": {
+    "debug": "^2.2.0",
     "mkdirp": "~0.5.1",
     "os-homedir": "^1.0.1",
     "progress": "~1.1.2",
     "rmrf": "~1.0.2",
-    "superagent": "~1.6.1",
+    "superagent": "^1.7.1",
     "through": "~2.3.8"
   },
   "devDependencies": {
-    "jsdocs": "^0.1.0"
+    "jsdoc": "^3.4.0"
   },
   "repository": {
     "type": "git",

--- a/rfc.1
+++ b/rfc.1
@@ -1,0 +1,54 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "RFC" "1" "February 2016" "" ""
+.
+.SH "NAME"
+\fBrfc\fR \-\- IETF RFC Reader Tool
+.
+.SH "SYNOPSIS"
+  \fBrfc\fR [\-rvVh] <command> [args \.\.\.]
+.
+.SH "OPTIONS"
+  \fB\-r, \-\-regex\fR       use regex query input
+  \fB\-v, \-\-verbose\fR     show verbose output
+  \fB\-V, \-\-version\fR     output version
+  \fB\-h, \-\-help\fR        display this message
+.
+.SH "COMMANDS"
+  \fBsync\fR              sync remote rfc index file
+  \fBsearch <query>\fR    search rfc index
+  \fBopen <rfc>\fR        open an rfc document by id
+  \fBlist\fR              list all local rfc documents
+  \fBclear\fR             clear local cache
+.
+.SH "DEBUG"
+  \fBDEBUG\fR tags: \fBrfc:search\fR, \fBrfc:match\fR, \fBrfc:sync\fR
+  See visionmedia/debug \fIhttps://github\.com/visionmedia/debug\fR for details on usage\.
+.
+.SH "AUTHOR"
+.
+.IP "\(bu" 4
+Joseph Werle \fIjoseph\.werle@gmail\.com\fR
+.
+.IP "" 0
+.
+.SH "REPORTING BUGS"
+.
+.IP "\(bu" 4
+\fIhttps://github\.com/jwerle/rfc/issues\fR
+.
+.IP "" 0
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+http://www\.ietf\.org/
+.
+.IP "\(bu" 4
+http://www\.ietf\.org/rfc
+.
+.IP "" 0
+.
+.SH "LICENSE"
+MIT

--- a/rfc.1.md
+++ b/rfc.1.md
@@ -20,6 +20,11 @@ rfc(1) -- IETF RFC Reader Tool
   `list`              list all local rfc documents
   `clear`             clear local cache
 
+## DEBUG
+
+  `DEBUG` tags: `rfc:search`, `rfc:match`, `rfc:sync`
+  See [visionmedia/debug](https://github.com/visionmedia/debug) for details on usage.
+
 ## AUTHOR
 
   - Joseph Werle <joseph.werle@gmail.com>

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
  * Module dependencies
  */
 
-var rfc = require('./')
+var rfc = require('./');
 
 if (false) {
   rfc.sync()
@@ -14,8 +14,19 @@ if (false) {
 var search = rfc.search('punycode');
 
 search.on('result', function (result) {
-  result.open().on('error', function (err) {
-    throw err;
-  });
+  if (result.isSynced()) {
+    return result.open()
+      .on('error', function (err) {
+        throw err;
+      });
+  }
+
+  result.sync()
+    .on('error', function (err) {
+      e('error: %s', err);
+    })
+    .on('end', function () {
+      result.open();
+    });
 });
 


### PR DESCRIPTION
[breaking] `search()` will no longer sync RFC automatically, call `sync()` manually before `open()`
`rfc open <query>` will open first result (if available)
update cli accordingly
update test accordingly
add debug logs
update dependencies
update jsdocs
update README and man page

 Changes to be committed:
	modified:   README.md
	modified:   bin/rfc
	modified:   index.js
	modified:   jsdoc.conf.json
	modified:   package.json
	new file:   rfc.1
	modified:   rfc.1.md
	modified:   test.js